### PR TITLE
bugfix: custom-http

### DIFF
--- a/http/response.ts
+++ b/http/response.ts
@@ -68,7 +68,7 @@ export class HttpResponse extends HttpMessage {
    * @returns {string}
    */
   private makeStatusLine(): string {
-    return new StringBuilder(`HTTP/${this.getVersion()}`) // HTTP-Version
+    return new StringBuilder(this.getVersion()) // HTTP-Version
       .add(SP)
       .add(this.statusCode.toString()) // Status-Code
       .add(SP)

--- a/http/utils/parsers/param.parser.ts
+++ b/http/utils/parsers/param.parser.ts
@@ -4,10 +4,7 @@
  * @param {string} route
  * @returns {Map<string, string>}
  */
-export default function parseParam(
-  uri: string,
-  route: string,
-): Map<string, string> {
+export function parseParam(uri: string, route: string): Map<string, string> {
   const uriSegments: string[] = uri.split('/').slice(1);
   const routeSegments: string[] = route.split('/').slice(1);
 

--- a/http/utils/parsers/request.parser.ts
+++ b/http/utils/parsers/request.parser.ts
@@ -68,11 +68,11 @@ function parseRequestLine(requestLine: string): ParsedRequestLine {
   if (!isValidRequestline(requestLine)) {
     return {};
   }
-  const splits: string[] = requestLine.split(SP).map((s) => s.replace('#', '')); // remove fragment
+  const splits: string[] = requestLine.split(SP);
   return {
-    method: splits.at(0) as HttpMethods,
+    method: splits.at(0).replace('#', '') as HttpMethods, // remove fragment
     uri: splits.at(1),
-    version: splits.at(2),
+    version: splits.at(2).replace(CRLF, ''), // remove CRLF
   };
 }
 

--- a/index.ts
+++ b/index.ts
@@ -3,3 +3,4 @@ export * from './http/response';
 export * from './http/interfaces';
 export * from './http/constants';
 export * from './http/utils/parsers/param.parser';
+export * from './http/errors/invalid-request-line.error';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kimyu0218/custom-http",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kimyu0218/custom-http",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "MIT",
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kimyu0218/custom-http",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kimyu0218/custom-http",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "license": "MIT",
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kimyu0218/custom-http",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kimyu0218/custom-http",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "MIT",
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kimyu0218/custom-http",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kimyu0218/custom-http",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "MIT",
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kimyu0218/custom-http",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "",
   "author": "kimyu0218 <serena35@naver.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kimyu0218/custom-http",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "",
   "author": "kimyu0218 <serena35@naver.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kimyu0218/custom-http",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "",
   "author": "kimyu0218 <serena35@naver.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kimyu0218/custom-http",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "",
   "author": "kimyu0218 <serena35@naver.com>",
   "license": "MIT",


### PR DESCRIPTION
- 에러 핸들링을 위해 `InvalidRequestLineError` 내보내기
- HTTP status-line 생성 오류 수정
- HTTP request-line 파싱 오류 수정 (맨 뒤의 CRLF 제거)